### PR TITLE
Update and fix tests for 3.7.0.

### DIFF
--- a/matplotview/tests/test_view_obj.py
+++ b/matplotview/tests/test_view_obj.py
@@ -8,6 +8,9 @@ import numpy as np
 
 def test_obj_comparison():
     from matplotlib.axes import Subplot, Axes
+    import matplotlib
+
+    mpl_version = tuple(int(v) for v in matplotlib.__version__.split("."))
 
     view_class1 = view_wrapper(Subplot)
     view_class2 = view_wrapper(Subplot)
@@ -15,7 +18,11 @@ def test_obj_comparison():
 
     assert view_class1 is view_class2
     assert view_class1 == view_class2
-    assert view_class2 != view_class3
+    if(mpl_version >= (3, 7, 0)):
+        # As of 3.7.0, the subplot class no long exists, and is an alias to the Axes class...
+        assert view_class2 == view_class3
+    else:
+        assert view_class2 != view_class3
 
 
 @check_figures_equal(tol=5.6)


### PR DESCRIPTION
As of matplotlib version 3.7.0, the old Subplot class (an Axes subclass which stored info about its grid location and layout) was removed, and is now simply a reference to the Axes class which implements all the needed functionality. This patch fixes a single test that relied on the pre-3.7.0 behavior, by checking the matplotlib version before making assertions about Subplot and Axes not being the same class. Otherwise, all matplotview functionality works on v3.7.0 as expected, so a new release won't be made yet.