### PR TITLE
Working with latest matplotlib, scale_lines also now scales markers.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -57,8 +57,17 @@ jobs:
           flake8 matplotview --count --select=E9,F63,F7,F82 --show-source --statistics
           flake8 matplotview --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
+        id: pytest
         run: |
           pytest
+
+      - name: Upload images on failure
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() && steps.pytest.conclusion == 'failure' }}
+        with:
+          name: test-result-images
+          retention-days: 1
+          path: result_images/
 
   test-windows:
 
@@ -82,5 +91,14 @@ jobs:
           pip install pytest
           pip install -r requirements.txt
       - name: Test with pytest
+        id: pytest
         run: |
           pytest
+
+      - name: Upload images on failure
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() && steps.pytest.conclusion == 'failure' }}
+        with:
+          name: test-result-images
+          retention-days: 1
+          path: result_images/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13", "3.13t"]
 
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13", "3.13t"]
 
     steps:
       - uses: actions/checkout@v4

--- a/matplotview/_transform_renderer.py
+++ b/matplotview/_transform_renderer.py
@@ -258,11 +258,11 @@ class _TransformRenderer(RendererBase):
         marker_trans,
         path,
         trans,
-        rgbFace = None,
+        rgbFace=None,
     ):
         # If the markers need to be scaled accurately (such as in log scale), just use the fallback as each will need
         # to be scaled separately.
-        if(self.__scale_widths):
+        if (self.__scale_widths):
             super().draw_markers(gc, marker_path, marker_trans, path, trans, rgbFace)
             return
 
@@ -296,7 +296,7 @@ class _TransformRenderer(RendererBase):
         offset_position,
     ):
         # If we want accurate scaling for each marker (such as in log scale), just use superclass implementation...
-        if(self.__scale_widths):
+        if (self.__scale_widths):
             super().draw_path_collection(
                 gc, master_transform, paths, all_transforms, offsets, offset_trans, facecolors,
                 edgecolors, linewidths, linestyles, antialiaseds, urls, offset_position
@@ -305,7 +305,7 @@ class _TransformRenderer(RendererBase):
 
         # Otherwise we transform just the offsets, and pass them to the backend.
         print(offsets)
-        if(np.any(np.isnan(offsets))):
+        if (np.any(np.isnan(offsets))):
             raise ValueError("???")
         offsets = self._get_transfer_transform(offset_trans).transform(offsets)
         print(offsets)

--- a/matplotview/tests/test_view_rendering.py
+++ b/matplotview/tests/test_view_rendering.py
@@ -244,7 +244,7 @@ def test_stop_viewing(fig_test, fig_ref):
 
 @check_figures_equal()
 def test_log_line(fig_test, fig_ref):
-    data = [i for i in range(10)]
+    data = [i for i in range(1, 10)]
 
     # Test case... Create a view and stop it...
     ax1_test, ax2_test = fig_test.subplots(1, 2)

--- a/matplotview/tests/test_view_rendering.py
+++ b/matplotview/tests/test_view_rendering.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import check_figures_equal
@@ -242,7 +244,7 @@ def test_stop_viewing(fig_test, fig_ref):
     ax1_ref.text(0.5, 0.5, "Hello")
 
 # On MacOS the results are off by an extremely tiny amount, can't even see in diff. It's close enough...
-@check_figures_equal(tol=0.02)
+@check_figures_equal(tol=0.02 if sys.platform.startswith("darwin") else 0)
 def test_log_line(fig_test, fig_ref):
     data = [i for i in range(1, 10)]
 

--- a/matplotview/tests/test_view_rendering.py
+++ b/matplotview/tests/test_view_rendering.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import check_figures_equal
@@ -241,8 +243,8 @@ def test_stop_viewing(fig_test, fig_ref):
     ax1_ref.plot(data)
     ax1_ref.text(0.5, 0.5, "Hello")
 
-
-@check_figures_equal()
+# On MacOS the results are off by an extremely tiny amount, can't even see in diff. It's close enough...
+@check_figures_equal(tol=0 if sys.platform.startswith("darwin") else 0.2)
 def test_log_line(fig_test, fig_ref):
     data = [i for i in range(1, 10)]
 

--- a/matplotview/tests/test_view_rendering.py
+++ b/matplotview/tests/test_view_rendering.py
@@ -244,7 +244,7 @@ def test_stop_viewing(fig_test, fig_ref):
     ax1_ref.text(0.5, 0.5, "Hello")
 
 # On MacOS the results are off by an extremely tiny amount, can't even see in diff. It's close enough...
-@check_figures_equal(tol=0 if sys.platform.startswith("darwin") else 0.2)
+@check_figures_equal(tol=0.02)
 def test_log_line(fig_test, fig_ref):
     data = [i for i in range(1, 10)]
 

--- a/matplotview/tests/test_view_rendering.py
+++ b/matplotview/tests/test_view_rendering.py
@@ -243,6 +243,7 @@ def test_stop_viewing(fig_test, fig_ref):
     ax1_ref.plot(data)
     ax1_ref.text(0.5, 0.5, "Hello")
 
+
 # On MacOS the results are off by an extremely tiny amount, can't even see in diff. It's close enough...
 @check_figures_equal(tol=0.02 if sys.platform.startswith("darwin") else 0)
 def test_log_line(fig_test, fig_ref):

--- a/matplotview/tests/test_view_rendering.py
+++ b/matplotview/tests/test_view_rendering.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import check_figures_equal

--- a/matplotview/tests/test_view_rendering.py
+++ b/matplotview/tests/test_view_rendering.py
@@ -240,3 +240,76 @@ def test_stop_viewing(fig_test, fig_ref):
 
     ax1_ref.plot(data)
     ax1_ref.text(0.5, 0.5, "Hello")
+
+
+@check_figures_equal()
+def test_log_line(fig_test, fig_ref):
+    data = [i for i in range(10)]
+
+    # Test case... Create a view and stop it...
+    ax1_test, ax2_test = fig_test.subplots(1, 2)
+
+    ax1_test.set(xscale="log", yscale="log")
+    ax1_test.plot(data, "-o")
+
+    view(ax2_test, ax1_test, scale_lines=False)
+    ax2_test.set_xlim(-1, 10)
+    ax2_test.set_ylim(-1, 10)
+
+    # Reference, just don't plot anything at all in the second axes...
+    ax1_ref, ax2_ref = fig_ref.subplots(1, 2)
+
+    ax1_ref.set(xscale="log", yscale="log")
+    ax1_ref.plot(data, "-o")
+    ax2_ref.plot(data, "-o")
+    ax2_ref.set_xlim(-1, 10)
+    ax2_ref.set_ylim(-1, 10)
+
+
+@check_figures_equal()
+def test_log_scatter(fig_test, fig_ref):
+    data = [i for i in range(1, 11)]
+
+    # Test case... Create a view and stop it...
+    ax1_test, ax2_test = fig_test.subplots(1, 2)
+
+    ax1_test.set(xscale="log", yscale="log")
+    ax1_test.scatter(data, data)
+
+    view(ax2_test, ax1_test, scale_lines=False)
+    ax2_test.set_xlim(-5, 15)
+    ax2_test.set_ylim(-5, 15)
+
+    # Reference, just don't plot anything at all in the second axes...
+    ax1_ref, ax2_ref = fig_ref.subplots(1, 2)
+
+    ax1_ref.set(xscale="log", yscale="log")
+    ax1_ref.scatter(data, data)
+    ax2_ref.scatter(data, data)
+    ax2_ref.set_xlim(-5, 15)
+    ax2_ref.set_ylim(-5, 15)
+
+
+@check_figures_equal()
+def test_log_scatter_with_colors(fig_test, fig_ref):
+    data = [i for i in range(1, 11)]
+    colors = list("rgbrgbrgbr")
+
+    # Test case... Create a view and stop it...
+    ax1_test, ax2_test = fig_test.subplots(1, 2)
+
+    ax1_test.set(xscale="log", yscale="log")
+    ax1_test.scatter(data, data, color=colors)
+
+    view(ax2_test, ax1_test, scale_lines=False)
+    ax2_test.set_xlim(-5, 15)
+    ax2_test.set_ylim(-5, 15)
+
+    # Reference, just don't plot anything at all in the second axes...
+    ax1_ref, ax2_ref = fig_ref.subplots(1, 2)
+
+    ax1_ref.set(xscale="log", yscale="log")
+    ax1_ref.scatter(data, data, color=colors)
+    ax2_ref.scatter(data, data, color=colors)
+    ax2_ref.set_xlim(-5, 15)
+    ax2_ref.set_ylim(-5, 15)


### PR DESCRIPTION
Updates to work with latest matplotlib, adjusted now so that `scale_lines=False` also prevents markers and patches from being scaled.